### PR TITLE
Update main.cpp

### DIFF
--- a/New_Card_Game_Assignment/main.cpp
+++ b/New_Card_Game_Assignment/main.cpp
@@ -332,7 +332,7 @@ Pile initializeDeck(Pile thePile)
 }
 
 // shuffles a deck of cards
-Pile shuffleDeck(Pile thePile)
+void shuffleDeck(Pile& thePile)
 {
     srand(time(NULL));
     // loops from position 51 to 1
@@ -351,7 +351,7 @@ Pile shuffleDeck(Pile thePile)
         thePile.playedCards[r] = atMax;
         thePile.playedCards[i] = atRandom;
     }
-    return thePile;
+    return;
 }
 
 // deletes a card
@@ -624,7 +624,7 @@ int main()
         player.computer3Points = 0;
         pile = initializePile(pile);
         pile = initializeDeck(pile);
-        pile = shuffleDeck(pile);
+        shuffleDeck(pile);
         pile = sortHand(pile);
         player = displayDeck(pile, player);
         cout << endl;


### PR DESCRIPTION
Right now when you shuffle the deck, here's what happens.
You create a second copy of `thePile` in memory. 
It is then shuffled
Then, it is returned
Then, you copy it back into the old pile.


Instead, why not just pass a reference to the old pile? Here's what happens
You pass a reference of the pile in
It is shuffled

When you pass a reference to a pile, you are sending the memory address of it-so that you are modifying the original one instead of a copy. You can do this with a lot of the functions like `initializePile` and `initializeDeck`.

Notice how we got rid of all of the copying inefficiencies! This will make the program use less RAM and run faster.
Have you checked out the issues that I posted?